### PR TITLE
Rebuild with latest protobuf.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
   number: 2
   # VS 2008 is not supported for libprotobuf
   skip: True  # [py<38]
+  skip: True  # [linux and s390x]
   ignore_run_exports:
     - libprotobuf
     - libstdcxx-ng

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "mysql-connector-python" %}
 {% set version = "8.4.0" %}
-{% set sha256 = "52944d6fa84c903fd70723a47d2f8c3153c50ae91773f1584a7bd30606c58b35" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/mysql/mysql-connector-python/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 52944d6fa84c903fd70723a47d2f8c3153c50ae91773f1584a7bd30606c58b35
   patches:
     - patches/0001-Typecast-password-to-const-char-explicitly-py3.patch
     - patches/0002-Fix-location-for-searching-mysql-headers-and-libs-on.patch
@@ -19,7 +18,7 @@ source:
     - patches/0006-Delete-openssl-vendor-ed-libs-only-if-provided.patch
 
 build:
-  number: 1
+  number: 2
   # VS 2008 is not supported for libprotobuf
   skip: True  # [py<38]
   ignore_run_exports:
@@ -38,8 +37,8 @@ requirements:
     - pip
     - setuptools
     - mysql {{ version }}  # [not win]
-    - protobuf 4.25.3
-    - libprotobuf 4.25.3
+    - protobuf 5.29.3
+    - libprotobuf 5.29.3
   run:
     - python
     - mysql  # [not win]


### PR DESCRIPTION
mysql-connector-python protobuf5 rebuild

**Destination channel:**  defaults

### Links

- [PKG-7577](https://anaconda.atlassian.net/browse/PKG-7577) 
- [Upstream repository](https://github.com/mysql/mysql-connector-python/tree/8.4.0)

### Explanation of changes:

- Update libprotobuf/protobuf pinnings. 


[PKG-7577]: https://anaconda.atlassian.net/browse/PKG-7577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ